### PR TITLE
Minor Fixes to Root and IP detection

### DIFF
--- a/supertool/functions.py
+++ b/supertool/functions.py
@@ -63,16 +63,17 @@ def composekey(mac,serial):
 
 # obtains lan IP
 def getlanip():
+    IP = None
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(0)
     try:
         s.connect(('10.254.254.254', 1))
         IP = s.getsockname()[0]
+        print("[Getlanip]: Acquired local IP {}".format(IP))
     except Exception:
         print("[Getlanip]: Unable to retrieve local address")
     finally:
         s.close()
-    print("[Getlanip]: Acquired local IP {}".format(IP))
     return IP
 
 # craft payload.sh

--- a/supertool/pages.py
+++ b/supertool/pages.py
@@ -35,7 +35,7 @@ def login(r,host,user,password):
 # lan status
 def lanstatus(r,host):
     a = r.get("http://{}/?_type=menuView&_tag=localNetStatus&Menu3Location=0".format(host))
-    a = r.get("http://{}}/?_type=menuData&_tag=status_lan_info_lua.lua".format(host))
+    a = r.get("http://{}/?_type=menuData&_tag=status_lan_info_lua.lua".format(host))
     print(a.text)
 
 # samba 

--- a/supertool/zte-supertool.py
+++ b/supertool/zte-supertool.py
@@ -43,7 +43,7 @@ except:
 
 if nousb == True:
     print("[nousb]: Running in nousb mode")
-    if os.getuid != 0 and os.geteuid() != 0:
+    if os.getuid() != 0 and os.geteuid() != 0:
         print("[nousb]: You need to be root for this mode to work! Stopping")
         exit(0)     
     


### PR DESCRIPTION
- Fixed a typo in lanstatus(): Extra "}" in the base url:
```
    a = r.get("http://{}}/?_type=loginData&_tag=login_token".format(host))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Single '}' encountered in format string
```
- Incorrect Root check: `os.getuid` being called instead of `os.getuid()`

- getlanip() raises unboundlocalerror: if s.connect() fails, it prints error